### PR TITLE
fix: restart webpack on app.tss change

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,10 @@ module.exports = function (api, options) {
 	});
 
 	const theme = compileConfig.theme;
-	const watchFiles = [ path.join(appDir, 'config.json') ];
+	const watchFiles = [
+		path.join(appDir, 'config.json'),
+		path.join(appDir, 'styles', 'app.tss')
+	];
 	if (theme) {
 		watchFiles.push(path.join(appDir, 'themes', theme, 'config.json'));
 	}
@@ -235,7 +238,8 @@ module.exports = function (api, options) {
 		config.plugin('watch-ignore')
 			.use(WatchIgnorePlugin, [
 				[
-					/alloy[/\\]CFG.js/
+					/alloy[/\\]CFG.js/,
+					/styles[/\\]app.tss/
 				]
 			]);
 


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-28054

When the `app.tss` changes the whole Webpack build needs to be restarted to make sure the style changes will be reflected in all components. This is due to a limitation in the style loader in alloy, which only loads the `app.tss` once on startup.