### PR TITLE
fix: pass correct options to import-loader

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,7 +137,10 @@ module.exports = function (api, options) {
 			.rule('backbone')
 				.test(/backbone\.js$/)
 				.use('imports-loader')
-					.loader('imports-loader?define=>false');
+					.loader('imports-loader')
+					.options({
+						additionalCode: 'const define = false;'
+					});
 
 		// plugins -----------------------------------------------------------------
 


### PR DESCRIPTION
The options for `imports-loader` changed. [Disabling AMD import syntax](https://github.com/webpack-contrib/imports-loader#disable-amd-import-syntax) is now done in the loader options instead via inline options.